### PR TITLE
forward logs from enclave to logserver

### DIFF
--- a/src/nautilus-server/allowed_endpoints.yaml
+++ b/src/nautilus-server/allowed_endpoints.yaml
@@ -1,3 +1,4 @@
 # External endpoints that the enclave is allowed to access. 
 endpoints:
   - api.twitter.com
+  - logserver


### PR DESCRIPTION
This PR:

- adds logserver in allowed_endpoints.yaml
- adds an entry for logserver into /etc/hosts:
- handles adding 8080 as the port for the logserver when adding to /etc/nitro_enclaves/vsock-proxy.yaml
- handles appending additional vsock-proxy commands for the extra endpoint